### PR TITLE
switch from require to include to break the dependency cycle

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,7 +39,7 @@ define logstash::config (
     default   => template($template),
   }
 
-  require logstash
+  include logstash
 
   file { "logstash.conf_${name}":
     ensure  => $ensure,


### PR DESCRIPTION
the last commit introduced a dependency cycle

switched to just include the parent class as the file resource already declares its dependency's
require => Class['logstash::install']
